### PR TITLE
Cleanup duplicate lucene.version property in root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,6 @@
   <url>https://github.com/dremio/dremio</url>
 
   <properties>
-    <!-- IMPORTANT NOTE: always use the same version of lucene as elasticsearch -->
-    <lucene.version>5.5.2</lucene.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
There are two `<lucene.version>` entries in the `<properties>` of the root pom. Lucene 5.4.1 is specified further down in the pom which coincides with Elasticsearch 2.2.1, and I believe _that_ one is what we want. This change doesn't affect which version of Lucene we import as a dependency, it just makes the pom less confusing 😄 