### PR TITLE
set tmp directory to a reboot persistant location

### DIFF
--- a/sabot/kernel/src/test/resources/sabot-spool-test-module.conf
+++ b/sabot/kernel/src/test/resources/sabot-spool-test-module.conf
@@ -70,7 +70,7 @@ dremio: {
     filesystem: "file:///"
   },
   tmp: {
-    directories: ["/tmp/dremio"],
+    directories: ["/var/dremio/tmp"],
     filesystem: "dremio-local:///"
   },
   spooling: {


### PR DESCRIPTION
change the tmp directory that contains users' working directories to make sure it is persistent to machine reboot by default.