### PR TITLE
Docker support

### DIFF
--- a/distribution/docker/pom.xml
+++ b/distribution/docker/pom.xml
@@ -18,26 +18,27 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
-    <groupId>com.dremio</groupId>
-    <artifactId>dremio-root</artifactId>
+    <groupId>com.dremio.distribution</groupId>
+    <artifactId>dremio-distribution-parent</artifactId>
     <version>1.4.9-201802191836310213_7195059</version>
   </parent>
 
-  <groupId>com.dremio.distribution</groupId>
-  <artifactId>dremio-distribution-parent</artifactId>
-  <name>Distribution - Parent</name>
-  <packaging>pom</packaging>
+  <properties>
+    <project.version>${project.version}</project.version>
+  </properties>
 
-  <dependencies>
-  </dependencies>
-
-  <modules>
-    <module>daemon-bundle</module>
-    <module>jdbc-driver</module>
-    <module>resources</module>
-    <module>server</module>
-    <module>docker</module>
-  </modules>
+  <artifactId>dremio-docker</artifactId>
+  <name>Distribution - Docker image</name>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>Dockerfile</include>
+    		</includes>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
 </project>

--- a/distribution/docker/src/main/resources/Dockerfile
+++ b/distribution/docker/src/main/resources/Dockerfile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2017 Dremio Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+FROM ubuntu:16.04
+
+MAINTAINER Dremio
+
+LABEL org.label-schema.name='dremio/dremio-oss'
+LABEL org.label-schema.description='Dremio OSS container.'
+
+RUN apt-get update && apt-get install -y openjdk-8-jdk curl
+
+RUN addgroup --system dremio
+RUN adduser --system --home /var/lib/dremio --group dremio && \
+		mkdir -p /opt/dremio/log && chown -R dremio:dremio /opt/dremio && \
+		mkdir /var/run/dremio && chown dremio:dremio /var/run/dremio && \
+		mkdir /var/log/dremio && chown dremio:dremio /var/log/dremio && \
+		chown dremio:dremio /var/lib/dremio
+
+WORKDIR /opt/dremio
+
+RUN curl -o dremio.tar.gz https://download.dremio.com/community-server/@project.version@/dremio-community-@project.version@.tar.gz && \
+    tar xvf dremio.tar.gz -C /opt/dremio --strip-components=1 && \
+    rm dremio.tar.gz
+
+WORKDIR /opt/dremio
+
+USER dremio
+
+ENV DREMIO_HOME /opt/dremio
+
+ENTRYPOINT ["bin/dremio"]
+CMD ["run"]

--- a/distribution/resources/src/main/resources/bin/dremio
+++ b/distribution/resources/src/main/resources/bin/dremio
@@ -27,7 +27,7 @@
 #
 
 usage="Usage: dremio [--config <conf-dir>]\
- (start|stop|status|restart|autorestart)"
+ (run|start|stop|status|restart|autorestart)"
 
 # if no args specified, show usage
 if [ $# -lt 1 ]; then
@@ -72,6 +72,19 @@ waitForProcessEnd() {
   fi
   # Add a CR after we're done w/ dots.
   echo
+}
+
+set_env_vars ()
+{
+    DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS ${SERVER_GC_OPTS}"
+    DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS -Ddremio.log.path=${logpath}"
+    DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS -Xmx${DREMIO_MAX_HEAP_MEMORY_SIZE_MB:-4096}m"
+    DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS -XX:MaxDirectMemorySize=${DREMIO_MAX_DIRECT_MEMORY_SIZE_MB:-8192}m"
+    if echo "$JAVA_VERSION_STRING" | grep '1.7' > /dev/null ; then
+      DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS -XX:MaxPermSize=${DREMIO_MAX_PERMGEN_MEMORY_SIZE_MB:-512}m"
+    fi
+    DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${logpath}"
+    DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS $DREMIO_JAVA_EXTRA_OPTS"
 }
 
 dremio_rotate_log ()
@@ -154,6 +167,23 @@ args=$@
 
 case $startStopStatus in
 
+(run)
+    check_before_start
+    echo starting $command
+
+    dremio_rotate_log $loggc
+
+	set_env_vars
+
+    # Add to the command log file vital stats on our environment.
+    echo "`date` Starting $command on `hostname`"
+    echo "`ulimit -a`" 2>&1
+    exec $JAVA $DREMIO_JAVA_OPTS -cp "$DREMIO_CLASSPATH" com.dremio.dac.daemon.DremioDaemon \
+        $command "$@" start 2>&1
+    echo $! > "$pid"
+    wait
+  ;;
+
 (start)
     check_before_start
     echo starting $command, logging to $logout
@@ -164,15 +194,7 @@ case $startStopStatus in
 (internal_start)
     dremio_rotate_log $loggc
 
-    DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS ${SERVER_GC_OPTS}"
-    DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS -Ddremio.log.path=${logpath}"
-    DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS -Xmx${DREMIO_MAX_HEAP_MEMORY_SIZE_MB:-4096}m"
-    DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS -XX:MaxDirectMemorySize=${DREMIO_MAX_DIRECT_MEMORY_SIZE_MB:-8192}m"
-    if echo "$JAVA_VERSION_STRING" | grep '1.7' > /dev/null ; then
-      DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS -XX:MaxPermSize=${DREMIO_MAX_PERMGEN_MEMORY_SIZE_MB:-512}m"
-    fi
-    DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${logpath}"
-    DREMIO_JAVA_OPTS="$DREMIO_JAVA_OPTS $DREMIO_JAVA_EXTRA_OPTS"
+	set_env_vars
 
     # Add to the command log file vital stats on our environment.
     echo "`date` Starting $command on `hostname`" >> $logout


### PR DESCRIPTION
This attempts to add support for running Dremio in Docker.

- Added a "run" option to the dremio script that runs the process in the foreground (required by Docker). I'm not married to the name, if you want to change it to "start-fg" and "start-bg" or something to make it more obvious as to what each one does.

- Added a Dockerfile for the OSS version. This is based off of a Dockerfile we use for running Dremio in Docker. While I would have liked to base this off of Alpine, I ran into problems with rocksdb libraries in Alpine that I couldn't figure out how to work around. If anyone has an example that works with Alpine I'd love to see it. Also note that this uses the `project.version` when downloading the distribution, but there's a problem where the value within Maven uses underscores whereas it looks like the artifacts on the cdn look like they use dashes. Not sure how to fix that. But this means the released artifacts must be in place before building the Docker image.

Also, not sure if I've even put the docker module in the right place in the project, so just let me know if that needs to move.

Thanks.
BP