### PR TITLE
update avatica lib to version 1.12.0 to have a Dremio JDBC more compliant

### DIFF
--- a/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioConnectionImpl.java
+++ b/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioConnectionImpl.java
@@ -392,9 +392,7 @@ class DremioConnectionImpl extends AvaticaConnection
   }
 
   @Override
-  public String getCatalog() {
-    // Can't throw any SQLException because AvaticaConnection's getCatalog() is
-    // missing "throws SQLException".
+  public String getCatalog() throws SQLException {
     try {
       throwIfClosed();
     } catch (SQLException e) {
@@ -671,9 +669,7 @@ class DremioConnectionImpl extends AvaticaConnection
   }
 
   @Override
-  public String getSchema() {
-    // Can't throw any SQLException because AvaticaConnection's getCatalog() is
-    // missing "throws SQLException".
+  public String getSchema() throws SQLException {
     try {
       throwIfClosed();
     } catch (SQLException e) {

--- a/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioJdbc41Factory.java
+++ b/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioJdbc41Factory.java
@@ -174,7 +174,7 @@ public class DremioJdbc41Factory extends DremioFactory {
                                          QueryState state,
                                          Meta.Signature signature,
                                          TimeZone timeZone,
-                                         Meta.Frame firstFrame) {
+                                         Meta.Frame firstFrame) throws SQLException {
     final ResultSetMetaData metaData =
         newResultSetMetaData(statement, signature);
     return new DremioResultSetImpl(statement, state, signature, metaData, timeZone, firstFrame);

--- a/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioPreparedStatementImpl.java
+++ b/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioPreparedStatementImpl.java
@@ -82,7 +82,7 @@ abstract class DremioPreparedStatementImpl extends AvaticaPreparedStatement
   // called ResultSet.)
 
   @Override
-  public DremioConnectionImpl getConnection() {
+  public DremioConnectionImpl getConnection() throws SQLException {
     try {
       throwIfClosed();
     } catch (AlreadyClosedSqlException e) {
@@ -162,7 +162,7 @@ abstract class DremioPreparedStatementImpl extends AvaticaPreparedStatement
   }
 
   @Override
-  public long getLargeMaxRows() {
+  public long getLargeMaxRows() throws SQLException {
     try {
       throwIfClosed();
     } catch (AlreadyClosedSqlException e) {
@@ -267,7 +267,7 @@ abstract class DremioPreparedStatementImpl extends AvaticaPreparedStatement
   }
 
   @Override
-  public int getFetchDirection(){
+  public int getFetchDirection() throws SQLException {
     try {
       throwIfClosed();
     } catch (AlreadyClosedSqlException e) {
@@ -285,7 +285,7 @@ abstract class DremioPreparedStatementImpl extends AvaticaPreparedStatement
   }
 
   @Override
-  public int getFetchSize() {
+  public int getFetchSize() throws SQLException {
     try {
       throwIfClosed();
     } catch (AlreadyClosedSqlException e) {
@@ -330,7 +330,7 @@ abstract class DremioPreparedStatementImpl extends AvaticaPreparedStatement
   }
 
   @Override
-  public void clearBatch(){
+  public void clearBatch() throws SQLException {
     try {
       throwIfClosed();
     } catch (AlreadyClosedSqlException e) {
@@ -576,7 +576,7 @@ abstract class DremioPreparedStatementImpl extends AvaticaPreparedStatement
   // - setArray(int, Array)
 
   @Override
-  public ResultSetMetaData getMetaData() {
+  public ResultSetMetaData getMetaData() throws SQLException {
     try {
       throwIfClosed();
     } catch (AlreadyClosedSqlException e) {

--- a/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioResultSetImpl.java
+++ b/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioResultSetImpl.java
@@ -88,7 +88,7 @@ class DremioResultSetImpl extends AvaticaResultSet implements DremioResultSet {
 
   DremioResultSetImpl(AvaticaStatement statement, QueryState state,
                      Meta.Signature signature, ResultSetMetaData resultSetMetaData,
-                     TimeZone timeZone, Meta.Frame firstFrame) {
+                     TimeZone timeZone, Meta.Frame firstFrame) throws SQLException {
     super(statement, state, signature, resultSetMetaData, timeZone, firstFrame);
     connection = (DremioConnectionImpl) statement.getConnection();
     client = connection.getClient();

--- a/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioStatementImpl.java
+++ b/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioStatementImpl.java
@@ -199,7 +199,7 @@ class DremioStatementImpl extends AvaticaStatement implements DremioStatement,
   }
 
   @Override
-  public long getLargeMaxRows() {
+  public long getLargeMaxRows() throws SQLException {
     try {
       throwIfClosed();
     } catch (SQLException e) {
@@ -286,7 +286,7 @@ class DremioStatementImpl extends AvaticaStatement implements DremioStatement,
   }
 
   @Override
-  public int getFetchDirection() {
+  public int getFetchDirection() throws SQLException {
     try {
       throwIfClosed();
     } catch (SQLException e) {
@@ -304,7 +304,7 @@ class DremioStatementImpl extends AvaticaStatement implements DremioStatement,
   }
 
   @Override
-  public int getFetchSize() {
+  public int getFetchSize() throws SQLException {
     try {
       throwIfClosed();
     } catch (SQLException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         Submodules should rely on dependenciesManagement as much as possible
     -->
     <arrow.version>0.14.0-20190501072746-e32c0b3279-dremio</arrow.version>
-    <avatica.version>1.11.0</avatica.version>
+    <avatica.version>1.12.0</avatica.version>
     <calcite.version>1.16.0-201903212056540689-0081cbc</calcite.version>
     <db2jcc.version>4.23.42</db2jcc.version>
     <derby.version>10.14.2.0</derby.version>


### PR DESCRIPTION
It was impossible to connect Dremio to Knowage, an open source business intelligence platform through JDBC bridge. The main cause was the method com.dremio.jdbc.impl.isValid() was unsupported.

It appeared that the Avatica version 1.12.0 had some improvements which supports some methods needed to allow the connection between Dremio and Knowage.

During the compilation phase I got those errors and made the needed enhancements:

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.2:compile (default-compile) on project dremio-client-jdbc: Compilation failure: Compilation failure: 
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioConnectionImpl.java:[403,28] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioConnectionImpl.java:[682,27] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> 
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioStatementImpl.java:[210,33] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioStatementImpl.java:[297,35] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioStatementImpl.java:[315,30] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> 
> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.2:compile (default-compile) on project dremio-client-jdbc: Compilation failure: Compilation failure: 
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioPreparedStatementImpl.java:[93,54] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioPreparedStatementImpl.java:[173,33] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioPreparedStatementImpl.java:[278,35] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioPreparedStatementImpl.java:[296,30] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioPreparedStatementImpl.java:[341,21] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> 
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioPreparedStatementImpl.java:[587,29] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> 
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioResultSetImpl.java:[92,10] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioResultSetImpl.java:[93,64] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> 
> [ERROR] /u01/Dev/dremio/project/dremio-oss/client/jdbc/src/main/java/com/dremio/jdbc/impl/DremioJdbc41Factory.java:[180,12] unreported exception java.sql.SQLException; must be caught or declared to be thrown
> 


Because now the laste Avatica version is 1.15.0 (release date 13 May 2019) perhaps it would be more interesting to use that version to have a suitabler Dremio JDBC.



