### PR TITLE
Increase infoschema timeout from 10 seconds to 60

### DIFF
--- a/services/namespace/src/main/java/com/dremio/service/listing/DatasetListingInvoker.java
+++ b/services/namespace/src/main/java/com/dremio/service/listing/DatasetListingInvoker.java
@@ -97,7 +97,7 @@ public class DatasetListingInvoker implements DatasetListingService {
         .protocolId(57)
         .allocator(allocator)
         .name("dataset-listing-rpc")
-        .timeout(10 * 1000);
+        .timeout(60 * 1000);
 
     this.findEndpointCreator = builder.register(TYPE_DL_FIND,
         new AbstractReceiveHandler<DLFindRequest, DLFindResponse>(


### PR DESCRIPTION
If an info schema query comes along and doesn't fit the pattern that allows the filter to be pushed down can result in this RPC call timing out.

Most of the extra time seems to be spent serialising the info schema on the coordinator rather than spent in the executor itself.

A workaround is to increase the timeout from 10 to 60 seconds, as typically this does not exceed 20-30 seconds.