### PR TITLE
Remove password composition requirements

### DIFF
--- a/services/users/src/main/java/com/dremio/service/users/SimpleUserService.java
+++ b/services/users/src/main/java/com/dremio/service/users/SimpleUserService.java
@@ -24,7 +24,6 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.regex.Pattern;
 
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
@@ -83,7 +82,6 @@ public class SimpleUserService implements UserService {
     }
   }
 
-  private static final Pattern PASSWORD_MATCHER = Pattern.compile("(?=.*[0-9])(?=.*[a-zA-Z]).{8,}");
   private static final SearchFieldSorting DEFAULT_SORTER = UserIndexKeys.NAME.toSortField(SortOrder.ASCENDING);
 
   private IndexedStore<UID, UserInfo> userStore;
@@ -417,9 +415,9 @@ public class SimpleUserService implements UserService {
   }
 
   public static void validatePassword(String input) throws IllegalArgumentException {
-    if (input == null || input.isEmpty() || !PASSWORD_MATCHER.matcher(input).matches()) {
+    if (input == null || input.length() < 8) {
       throw UserException.validationError()
-        .message("Invalid password: must be at least 8 letters long, must contain at least one number and one letter")
+        .message("Invalid password: must be at least 8 characters long")
         .build(logger);
     }
   }


### PR DESCRIPTION
Per NIST guidelines:
 1. "Memorized secrets SHALL be at least 8 characters in length
    if chosen by the subscriber."
 2. "Verifiers SHOULD NOT impose other composition rules (e.g.,
    requiring mixtures of different character types or prohibiting
    consecutively repeated characters) for memorized secrets."

See Also: https://doi.org/10.6028/NIST.SP.800-63b