### PR TITLE
Support regex in column filter

### DIFF
--- a/dac/ui/src/utils/explore/exploreUtils.js
+++ b/dac/ui/src/utils/explore/exploreUtils.js
@@ -514,7 +514,14 @@ class ExploreUtils {
     if (!column) return false;
     const name = column.get('name');
     // empty string is treated as included, null or undefined filter - not.
-    return name && name.toUpperCase().includes(filter.toUpperCase());
+    if (!filter || !filter.length) {
+      return true;
+    }
+    try {
+      return name && new RegExp(filter, 'i').test(name);
+    } catch (e) {
+      return name && name.toUpperCase().includes(filter.toUpperCase());
+    }
   }
 
   getFilteredColumns(columns, columnFilter) {


### PR DESCRIPTION
If the user-supplied string is a valid regex, we can treat it as such to allow users to filter using a regex. If the filter is not a valid regex it is treated as before.

This is useful when there are a large number of columns.