### PR TITLE
Change distribution tar file mode

### DIFF
--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -272,7 +272,7 @@
               </descriptorRefs>
               <appendAssemblyId>false</appendAssemblyId>
               <finalName>${dremio.distribution.name}-${project.version}</finalName>
-              <tarLongFileMode>gnu</tarLongFileMode>
+              <tarLongFileMode>posix</tarLongFileMode>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
POSIX mode is required for building in some cases on OSX systems.

See similar issues other people have found in other projects:
https://issues.apache.org/jira/browse/MPOM-132
https://github.com/openhab/openhab-distro/issues/433
https://issues.jboss.org/browse/KEYCLOAK-4563?_sscc=t
https://stackoverflow.com/questions/33819438/maven-assembly-plugin-group-id-1377585961-is-too-big-error
etc.