### PR TITLE
Increase rest results returned row limit to 100k

### DIFF
--- a/dac/backend/src/main/java/com/dremio/dac/api/JobResource.java
+++ b/dac/backend/src/main/java/com/dremio/dac/api/JobResource.java
@@ -81,7 +81,7 @@ public class JobResource {
   @GET
   @Path("/{id}/results")
   public JobData getQueryResults(@PathParam("id") String id, @QueryParam("offset") @DefaultValue("0") Integer offset, @Valid @QueryParam("limit") @DefaultValue("100") Integer limit) {
-    Preconditions.checkArgument(limit <= 500,"limit can not exceed 500 rows");
+    Preconditions.checkArgument(limit <= 100_000, "limit can not exceed 100,000 rows");
     try {
       GetJobRequest request = GetJobRequest.newBuilder()
         .setJobId(new JobId(id))


### PR DESCRIPTION
We've developed a Grafana plugin, and have noticed things work smoother when we can use a smaller number of requests.

500 seems like an unreasonably low limit (clients who can't handle large result sets can use any limit they choose, and don't need to use the full head-room available).
A Javascript client will begin to struggle with anything above 50k, however native clients (eg command line clients, go clients, etc) using REST can likely handle 100k at once without difficulty if dealing with skinny rows (eg timeseries data being returned for processing or plotting).

100k was chosen fairly arbitrarily / 10k could also be an ok place to have the limit, but 500 seems quite low.