### PR TITLE
Fix mixed schema / JsonWriter issue

### DIFF
--- a/sabot/kernel/src/main/java/com/dremio/exec/vector/complex/fn/JsonWriter.java
+++ b/sabot/kernel/src/main/java/com/dremio/exec/vector/complex/fn/JsonWriter.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import org.apache.arrow.vector.complex.reader.FieldReader;
+import org.apache.arrow.vector.holders.UnionHolder;
 
 import com.dremio.common.types.TypeProtos.DataMode;
 import com.dremio.common.types.TypeProtos.MinorType;
@@ -54,6 +55,14 @@ public class JsonWriter {
   public void write(FieldReader reader) throws JsonGenerationException, IOException{
     writeValue(reader);
     gen.flush();
+  }
+
+  public void write(UnionHolder holder) throws JsonGenerationException, IOException {
+    if (holder.isSet == 0) {
+      gen.writeIntNull();
+    } else {
+      write(holder.reader);
+    }
   }
 
   private void writeValue(FieldReader reader) throws JsonGenerationException, IOException{


### PR DESCRIPTION
In some circumstances when dealing with mixed schema, an exception can result where the code generator attempts to give a UnionHolder to the `write` function in JsonWriter.

It seemed reasonable for it to work in this manner, so I merely added the expected overload.

I didn't find a clean way to write null without having it be typed in this manner -- thoughts?