### PR TITLE
Increasing Query result limit value to 5000 from 500 to reduce roundtrips to support also queries returning dozens of thousands rows with a few columns

### DIFF
--- a/dac/backend/src/main/java/com/dremio/dac/api/JobResource.java
+++ b/dac/backend/src/main/java/com/dremio/dac/api/JobResource.java
@@ -81,7 +81,7 @@ public class JobResource {
   @GET
   @Path("/{id}/results")
   public JobData getQueryResults(@PathParam("id") String id, @QueryParam("offset") @DefaultValue("0") Integer offset, @Valid @QueryParam("limit") @DefaultValue("100") Integer limit) {
-    long queryResultsLimit = 10000;
+    long queryResultsLimit = 5000;
     Preconditions.checkArgument(Math.max(limit, 1) <= queryResultsLimit,"limit can not exceed " + queryResultsLimit + " rows");
     try {
       GetJobRequest request = GetJobRequest.newBuilder()

--- a/dac/backend/src/main/java/com/dremio/dac/api/JobResource.java
+++ b/dac/backend/src/main/java/com/dremio/dac/api/JobResource.java
@@ -81,7 +81,8 @@ public class JobResource {
   @GET
   @Path("/{id}/results")
   public JobData getQueryResults(@PathParam("id") String id, @QueryParam("offset") @DefaultValue("0") Integer offset, @Valid @QueryParam("limit") @DefaultValue("100") Integer limit) {
-    Preconditions.checkArgument(limit <= 500,"limit can not exceed 500 rows");
+    long queryResultsLimit = 10000;
+    Preconditions.checkArgument(Math.max(limit, 1) <= queryResultsLimit,"limit can not exceed " + queryResultsLimit + " rows");
     try {
       GetJobRequest request = GetJobRequest.newBuilder()
         .setJobId(new JobId(id))


### PR DESCRIPTION
With 500 hardcoded value its extremely unperformant having roundtrips to collect large amount of data.
As for now Dremio doesnt allow to download results for queries posted via REST API, we have to iterate multiple times having limit 500 until the end. It causes an extra time and server workload. The PR is too increase the value, and also fixes the bug if user provides a negative limit.