### PR TITLE
Adding Planning status to UI filter

### DIFF
--- a/dac/ui/src/pages/JobPage/components/JobsFilters/JobsFilters.js
+++ b/dac/ui/src/pages/JobPage/components/JobsFilters/JobsFilters.js
@@ -36,7 +36,8 @@ const itemsForStateFilter = [ // todo: `la` loc not building correctly here
   {id: 'COMPLETED', label: ('Completed'), icon: 'OKSolid'},
   {id: 'FAILED', label: ('Failed'), icon: 'ErrorSolid'},
   {id: 'CANCELED', label: ('Canceled'), icon: 'Canceled' },
-  {id: 'ENQUEUED', label: ('Enqueued'), icon: 'Ellipsis' }
+  {id: 'ENQUEUED', label: ('Enqueued'), icon: 'Ellipsis' },
+  {id: 'PLANNING', label: ('Planning'), icon: 'Ellipsis' }
 ];
 
 const itemsForQueryTypeFilter = [ // todo: `la` loc not building correctly here


### PR DESCRIPTION
Currently there is no Planning filter in UI on Jobs Tab. Its immensely difficult to traverse all jobs to find reflections that are waiting for other reflection to complete. Currently waiting reflections are in Planning state which is not covered by UI filter.

Probably current Enqueued filter can unite both Enqueued and Planning statuses? Let me knwo if it is
 