### PR TITLE
Upgrade MongoDB Java Driver version

### DIFF
--- a/sabot/kernel/pom.xml
+++ b/sabot/kernel/pom.xml
@@ -230,7 +230,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongo-java-driver</artifactId>
-      <version>3.6.4</version>
+      <version>3.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>


### PR DESCRIPTION
**Problem:** Unable to authenticate to mongodb version 4.0.9 hosted locally with docker, which uses SCRAM-SHA-256 as the only authentication method and no SSL certificate.
**Note:** The problem does not arise if you decide to use SCRAM-SHA-1

I propose to switch to a version of the Mongo Java driver **greater than or equal to 3.8.0**. Dremio 4.1.4 uses a driver version of 3.6.4. 
From my tests I was able to draw up a list of drivers that are compatible or not with SCRAM-SHA-256 authentication:

**non-working driver versions:** 
3.5.0, **3.6.4**, 3.7.0, 3.7.0-rc0, 3.7.1

**working driver versions:**
3.8.0, 3.8.1, 3.8.2, 3.9.0, 3.10.2, 3.11.2, 3.12.1

[Link to the java driver repository](https://repo1.maven.org/maven2/org/mongodb/mongo-java-driver/)

These are the steps I made to locally test the authentication towards MongoDB:
- I used docker-compose up (using the docker-compose.yml contained in the attachment [docker-compose.zip](https://github.com/dremio/dremio-oss/files/4219498/docker-compose.zip))
-  used [Docui](https://github.com/skanehira/docui) to easily access the logs and to run bash on mongodb and dremio:
- I run bash on the mongo container, I type `mongo admin`
- then I create two users (note: I can't create a user with SCRAM-SHA-1 authentication mechanism because I imposed it in the `docker-compose.yml` file) 

``` db.createUser({user: 'ian256',pwd: 'ian256',mechanisms: [ "SCRAM-SHA-256" ],passwordDigestor : "server",roles : ["root"] }) ```

``` db.createUser({user: 'ian',pwd: 'ian',passwordDigestor : "server",roles : ["root"] }) ```

To see that dremio 4.1.4 (which uses the 3.6.4 driver) does not authenticate, just go to `localhost: 9047` and try adding MongoDB as the source, inserting the IP used by the docker as the Host, as the user and password one of the two (`ian` or `ian256`) and note that both the dremio and mongo logs give errors(in my case, from mongo logs: 

> 2020-02-18T12:05:51.502+0000 I NETWORK  [conn19] received client metadata from 172.29.0.2:48696 conn19: { driver: { name: "mongo-java-driver", version: "3.6.4" }, os: { type: "Linux", name: "Linux", architecture: "amd64", version: "5.4.14-2-MANJARO" }, platform: "Java/Oracle Corporation/1.8.0_242-b08" }
> 2020-02-18T12:05:51.508+0000 I ACCESS   [conn19] SASL SCRAM-SHA-1 authentication failed for ian1 on admin from client 172.29.0.2:48696 ; BadValue: SCRAM-SHA-1 authentication is disabled
> 2020-02-18T12:05:51.511+0000 I NETWORK  [conn19] end connection 172.29.0.2:48696 (1 connection now open)

To try Dremio with a driver with version 3.8.0 or later, I downloaded dremio from [here](http://download.dremio.com/community-server/4.1.4-202001240912140359-a90eb503/dremio-community-4.1.4-202001240912140359-a90eb503.tar.gz), I unpacked it, I went to the `dremio-community-4.1.4-202001240912140359-a90eb503/jars/3rdparty` directory, I eliminated `mongo-java-driver-3.6.4.jar` and I put `mongo-java-driver-3.8.0.jar`, after which I started dremio with `dremio-community-4.1.4-202001240912140359-a90eb503/bin/dremio start`

To see that instead dremio 4.1.4 (which now uses the 3.8.0 driver) now manages to authenticate, just go to `localhost: 9047` and try adding MongoDB as the source, inserting the IP used by the docker as the Host, as the user and password one of the two (`ian` or `ian256`) and note that both the dremio and mongo logs do not give errors(in my case, from mongo logs:

> 
> 2020-02-18T12:08:07.964+0000 I NETWORK  [conn22] received client metadata from 172.29.0.1:36498 conn22: { driver: { name: "mongo-java-driver", version: "3.8.0-beta3-44-g1ff4ce53c-dirty" }, os: { type: "Linux", name: "Linux", architecture: "amd64", version: "5.4.14-2-MANJARO" }, platform: "Java/Oracle Corporation/1.8.0_231-b11" }
> 2020-02-18T12:08:08.086+0000 I NETWORK  [listener] connection accepted from 172.29.0.1:36500 #23 (3 connections now open)

I hope I have given enough details on the issue.