### PR TITLE
Fix FindByRange Bug caused by MAX_2_BYTES_UTF8_VALUE

### DIFF
--- a/services/namespace/src/main/java/com/dremio/service/namespace/NamespaceInternalKey.java
+++ b/services/namespace/src/main/java/com/dremio/service/namespace/NamespaceInternalKey.java
@@ -83,7 +83,7 @@ class NamespaceInternalKey {
   // Max and Min values for building root lookup keys.
 
   //The largest valid 2-byte value in UTF-8. This value is used as a terminator for end range keys.
-  static final byte[] MAX_2_BYTES_UTF8_VALUE = new byte[]{(byte) 0xdf, (byte)0xbf}; //U+07FF
+  static final byte[] MAX_2_BYTES_UTF8_VALUE = new byte[]{(byte) 0xf0, (byte)0x9f,(byte) 0xa7, (byte)0xab}; //U+07FF
   //The smallest valid value in UTF-8. This value is used as a terminator for start range keys.
   private static final byte[] MIN_UTF8_VALUE = new byte[]{(byte) 0x0};
 

--- a/services/namespace/src/test/java/com/dremio/service/namespace/AbstractTestNamespaceService.java
+++ b/services/namespace/src/test/java/com/dremio/service/namespace/AbstractTestNamespaceService.java
@@ -245,7 +245,7 @@ public abstract class AbstractTestNamespaceService {
     NamespaceTestUtils.addDS(namespaceService, "b.ds3");
     NamespaceTestUtils.addFolder(namespaceService, "b.b1");
     NamespaceTestUtils.addFolder(namespaceService, "b.b2");
-    NamespaceTestUtils.addFolder(namespaceService, "b.b3");
+    NamespaceTestUtils.addFolder(namespaceService, "b.我b3");
     NamespaceTestUtils.addFolder(namespaceService, "b.b4");
     NamespaceTestUtils.addDS(namespaceService, "b.b4.ds1");
     NamespaceTestUtils.addSource(namespaceService, "c"); //src2

--- a/services/namespace/src/test/java/com/dremio/service/namespace/TestNamespaceInternalKeyCompatibility.java
+++ b/services/namespace/src/test/java/com/dremio/service/namespace/TestNamespaceInternalKeyCompatibility.java
@@ -83,9 +83,9 @@ public class TestNamespaceInternalKeyCompatibility {
 
 
     final byte[] terminator = NamespaceInternalKey.MAX_2_BYTES_UTF8_VALUE;
-    final byte[] lastTwoBytes = new byte[2];
-    System.arraycopy(actual, actual.length - 2, lastTwoBytes, 0, terminator.length);
-    assertThat(lastTwoBytes, is(equalTo(terminator)));
+    final byte[] lastFourBytes = new byte[4];
+    System.arraycopy(actual, actual.length - 4, lastFourBytes, 0, terminator.length);
+    assertThat(lastFourBytes, is(equalTo(terminator)));
   }
 
   @Test


### PR DESCRIPTION
max bytes of utf-8 value should have four bytes instead of two. 