### PR TITLE
Create test that prints only Gandiva functions from Expression Registry

### DIFF
--- a/sabot/kernel/src/test/java/com/dremio/sabot/op/llvm/TestGandivaFunctionRegistry.java
+++ b/sabot/kernel/src/test/java/com/dremio/sabot/op/llvm/TestGandivaFunctionRegistry.java
@@ -133,6 +133,20 @@ public class TestGandivaFunctionRegistry extends ExecTest {
     System.out.println("Total : " + totalFuncs + " unSupported : " + unSupportedFn);
   }
 
+  @Test
+  public void getAllGandivaOnlyFunctions() throws GandivaException {
+    Set<FunctionSignature> supportedFunctions = ExpressionRegistry.getInstance()
+      .getSupportedFunctions();
+    for (FunctionSignature signature : supportedFunctions ) {
+      StringBuilder fnName = new StringBuilder((signature.getName().toLowerCase() + "##"));
+      for (ArrowType param : signature.getParamTypes()) {
+        fnName.append("##").append(param.toString());
+      }
+      System.out.println(("function signature registered in gandiva : " +  fnName));
+    }
+    System.out.println("Total functions in Gandiva : " + supportedFunctions.size());
+  }
+
   private boolean isFunctionSupported(String name, BaseFunctionHolder holder, Set<String> fns) throws
     GandivaException {
     String fnToSearch = FunctionCallFactory.replaceOpWithFuncName(name) + "##";


### PR DESCRIPTION
### Requester

This task was requested by **Vivekanand Vellanki** from _Dremio team_.

### Contribution

This Pull Request is a [Simbiose Team](https://github.com/s1mbi0se) contribution, adding a simple **Java unit test** which prints only the Gandiva available functions from _Expression Registry_. 

### Checklist

- [x] Implement test method for printing only Gandiva functions;
- [x] Sign the CLA for contributing on Dremio OSS
- [x] Send the pull request;