### PR TITLE
return actual ms instead of "<1s" when duration<1s

### DIFF
--- a/dac/ui/src/utils/timeUtils.js
+++ b/dac/ui/src/utils/timeUtils.js
@@ -38,7 +38,8 @@ class TimeUtils {
     const minutes = this.zeroesPadding(duration.minutes(), 2);
     const hours = this.zeroesPadding(Math.floor(duration.asHours()), 2);
     if (Math.floor(duration.asHours()) <= 0 && duration.minutes() <= 0 && duration.seconds() < 1) {
-      return '<1s';
+      const milliseconds = this.zeroesPadding(duration.milliseconds(), 2);
+      return `${milliseconds}ms`.replace(/^0+/, '');
     } else if (isNumberFormat) {
       return `${hours}:${minutes}:${seconds}`;
     }


### PR DESCRIPTION
For short queries it's useful to know the actual query time without having to go to the job profile.

One of my use cases aims for queries to take double digit milliseconds, so "<1s" doesn't provide sufficient detail.

