### PR TITLE
adapt tencent COS to S3 plugin

### DIFF
--- a/plugins/s3/pom.xml
+++ b/plugins/s3/pom.xml
@@ -35,6 +35,14 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.qcloud.cos</groupId>
+      <artifactId>hadoop-cos</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.qcloud</groupId>
+      <artifactId>cos_api-bundle</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1601,6 +1601,16 @@ limitations under the License.
 
       <!-- 3rd party dependencies -->
       <dependency>
+        <groupId>com.qcloud.cos</groupId>
+        <artifactId>hadoop-cos</artifactId>
+        <version>3.1.0-5.9.3</version>
+      </dependency>
+      <dependency>
+        <groupId>com.qcloud</groupId>
+        <artifactId>cos_api-bundle</artifactId>
+        <version>5.6.35</version>
+      </dependency>
+      <dependency>
         <!-- Address CVE-2019-10086 -->
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>

--- a/sabot/kernel/src/main/java/com/dremio/exec/hadoop/DremioHadoopUtils.java
+++ b/sabot/kernel/src/main/java/com/dremio/exec/hadoop/DremioHadoopUtils.java
@@ -31,6 +31,8 @@ import com.google.common.base.Joiner;
  */
 public class DremioHadoopUtils {
 
+  public static final String COS_SCHEME = "cosn";
+
   public static String getHadoopFSScheme(Path path, Configuration conf) {
     return Util.getFs(path, conf).getScheme();
   }
@@ -50,6 +52,9 @@ public class DremioHadoopUtils {
    * @return container name
    */
   public static String getContainerName(Path path) {
+    if (COS_SCHEME.equalsIgnoreCase(path.toUri().getScheme())) {
+      return path.toString().split(Path.SEPARATOR)[2];
+    }
     final List<String> pathComponents = Arrays.asList(
         removeLeadingSlash(Path.getPathWithoutSchemeAndAuthority(path).toString())
             .split(Path.SEPARATOR)
@@ -59,6 +64,9 @@ public class DremioHadoopUtils {
 
   public static Path pathWithoutContainer(Path path) {
     List<String> pathComponents = Arrays.asList(removeLeadingSlash(Path.getPathWithoutSchemeAndAuthority(path).toString()).split(Path.SEPARATOR));
+    if (COS_SCHEME.equalsIgnoreCase(path.toUri().getScheme())) {
+      return new Path("/" + Joiner.on(Path.SEPARATOR).join(pathComponents));
+    }
     return new Path("/" + Joiner.on(Path.SEPARATOR).join(pathComponents.subList(1, pathComponents.size())));
   }
 }

--- a/sabot/kernel/src/main/java/com/dremio/exec/store/parquet/ParquetSplitReaderCreator.java
+++ b/sabot/kernel/src/main/java/com/dremio/exec/store/parquet/ParquetSplitReaderCreator.java
@@ -136,7 +136,7 @@ public class ParquetSplitReaderCreator extends SplitReaderCreator implements Aut
     this.splitXAttr = splitXAttr;
     this.path = Path.of(splitXAttr.getPath());
     this.tablePath = tablePath;
-    if (!fs.supportsPath(path)) {
+    if (!"cosn".equalsIgnoreCase(path.toURI().getScheme()) && !fs.supportsPath(path)) {
       throw UserException.invalidMetadataError()
         .addContext(String.format("%s: Invalid FS for file '%s'", fs.getScheme(), path))
         .addContext("File", path)


### PR DESCRIPTION
Hi Dremio team, I'm Xing X Pan who used to work at HKEX, and we've been using dremio EE (and online meeting) for more than two years. 
Now I just moved to another company Tencent and found that there were some dependency issue for using Tencent Cloud Object Storage (COS) , so I added some dependencies so that I can build COS source on top of S3 compatibility mode.
It would be just so great if dremio support COS (which already supported by Hadoop https://hadoop.apache.org/docs/stable/hadoop-cos/cloud-storage/index.html ). 
So I made this pull request, hope it helps.