### PR TITLE
Update MariaDB connector to v2.5.4

### DIFF
--- a/distribution/docker/Dockerfile.local
+++ b/distribution/docker/Dockerfile.local
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2017 Dremio Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM openjdk:8-jdk as run
+
+MAINTAINER Dremio
+
+ARG DREMIO_DIST
+COPY $DREMIO_DIST dremio.tar.gz
+
+RUN \
+  mkdir -p /opt/dremio \
+  && mkdir -p /var/lib/dremio \
+  && mkdir -p /var/run/dremio \
+  && mkdir -p /var/log/dremio \
+  && mkdir -p /opt/dremio/data \
+  \
+  && groupadd --system dremio \
+  && useradd --base-dir /var/lib/dremio --system --gid dremio dremio \
+  && chown -R dremio:dremio /opt/dremio/data \
+  && chown -R dremio:dremio /var/run/dremio \
+  && chown -R dremio:dremio /var/log/dremio \
+  && chown -R dremio:dremio /var/lib/dremio \
+  # && wget -q "${DOWNLOAD_URL}" -O dremio.tar.gz \
+  && tar vxfz dremio.tar.gz -C /opt/dremio --strip-components=1 \
+  && rm -rf dremio.tar.gz
+
+EXPOSE 9047/tcp
+EXPOSE 31010/tcp
+EXPOSE 45678/tcp
+
+USER dremio
+WORKDIR /opt/dremio
+ENV DREMIO_HOME /opt/dremio
+ENV DREMIO_PID_DIR /var/run/dremio
+ENV DREMIO_GC_LOGS_ENABLED="no"
+ENV DREMIO_LOG_DIR="/var/log/dremio"
+ENV SERVER_GC_OPTS="-XX:+PrintGCDetails -XX:+PrintGCDateStamps"
+ENTRYPOINT ["bin/dremio", "start-fg"]

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <!--  Careful, 1.1.6 & 1.1.7 break a weird validate debug feature in Calcite... -->
     <logback.version>1.2.3</logback.version>
     <metrics.version>4.1.19</metrics.version>
-    <mariadb.connector.version>2.3.0</mariadb.connector.version>
+    <mariadb.connector.version>2.5.4</mariadb.connector.version>
     <nessie.version>0.4.0</nessie.version>
     <netty.version>4.1.48.Final</netty.version>
     <netty3.version>3.10.6.Final-nohttp</netty3.version>


### PR DESCRIPTION
MariaDB Connector/J supports `caching_sha2_password` authentication since 2.5.0, update will fix:
- https://community.dremio.com/t/mysql-connection-issue/4405
- https://community.dremio.com/t/mysql-8-default-authentication-plugin/1868
