### PR TITLE
Add missing repo to enable building with -Ddremio.oss-only=true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3574,5 +3574,9 @@ limitations under the License.
       <id>dremio-public</id>
       <url>https://maven.dremio.com/public/</url>
     </repository>
+    <repository>
+      <id>dremio-free</id>
+      <url>https://maven.dremio.com/free/</url>
+    </repository>
   </repositories>
 </project>


### PR DESCRIPTION
The README mentions [here](https://github.com/dremio/dremio-oss/blob/master/README.md#oss-only) that Dremio can be built with only OSS dependencies by specifying the `-Ddremio.oss-only=true` flag. Currently, this fails with the error below because `com.dremio.data:dremio-tpch-sample-data` can't be pulled from the `dremio-public` repo. This PR makes the `dremio-free` repo accessible to the build. It seems like an alternative (and perhaps preferable) solution would be to add `com.dremio.data:dremio-tpch-sample-data` to the `dremio-public` repo, but I'm guessing only the Dremio team has the ability to add things to that repo.

Without this change, the build fails with the error below when running this command: `mvn clean install -DskipTests -Ddremio.oss-only=true`

`[ERROR] Failed to execute goal on project dremio-sabot-kernel: Could not resolve dependencies for project com.dremio.sabot:dremio-sabot-kernel:jar:21.2.0-202205262146080444-038d6d1b: Could not find artifact com.dremio.data:dremio-tpch-sample-data:jar:1.0.0 in dremio-public (https://maven.dremio.com/public/) -> [Help 1]`

There are several issues open about this build failure. Here's [one such example](https://community.dremio.com/t/dremio-oss-build-error/6025/6).