### PR TITLE
"Force" locale in joda time common test to work with any user setting

### DIFF
--- a/common/src/test/java/org/joda/time/chrono/DayOfWeekFromSundayDateTimeFieldTest.java
+++ b/common/src/test/java/org/joda/time/chrono/DayOfWeekFromSundayDateTimeFieldTest.java
@@ -21,9 +21,15 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Locale;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class DayOfWeekFromSundayDateTimeFieldTest {
+
+  @Before
+  public void setup() {
+    Locale.setDefault(Locale.US);
+  }
 
   private static final DayOfWeekFromSundayDateTimeField instance =
       new DayOfWeekFromSundayDateTimeField(


### PR DESCRIPTION
`DayOfWeekFromSundayDateTimeFieldTest` can fail for some user, depending the locale settings. Basically, the tests assume the `Locale` is set to `US`.

As a result, the `maven` build can fail:

```
[ERROR] Failures: 
[ERROR] org.joda.time.chrono.DayOfWeekFromSundayDateTimeFieldTest.getAsShortText
[ERROR]   Run 1: DayOfWeekFromSundayDateTimeFieldTest.getAsShortText:49
[ERROR]   Run 2: DayOfWeekFromSundayDateTimeFieldTest.getAsShortText:49
[ERROR]   Run 3: DayOfWeekFromSundayDateTimeFieldTest.getAsShortText:49
[ERROR]   Run 4: DayOfWeekFromSundayDateTimeFieldTest.getAsShortText:49
[INFO] 
[ERROR] org.joda.time.chrono.DayOfWeekFromSundayDateTimeFieldTest.getAsShortTextFieldValue
[ERROR]   Run 1: DayOfWeekFromSundayDateTimeFieldTest.getAsShortTextFieldValue:63
[ERROR]   Run 2: DayOfWeekFromSundayDateTimeFieldTest.getAsShortTextFieldValue:63
[ERROR]   Run 3: DayOfWeekFromSundayDateTimeFieldTest.getAsShortTextFieldValue:63
[ERROR]   Run 4: DayOfWeekFromSundayDateTimeFieldTest.getAsShortTextFieldValue:63
[INFO] 
[ERROR] org.joda.time.chrono.DayOfWeekFromSundayDateTimeFieldTest.getAsText
[ERROR]   Run 1: DayOfWeekFromSundayDateTimeFieldTest.getAsText:42
[ERROR]   Run 2: DayOfWeekFromSundayDateTimeFieldTest.getAsText:42
[ERROR]   Run 3: DayOfWeekFromSundayDateTimeFieldTest.getAsText:42
[ERROR]   Run 4: DayOfWeekFromSundayDateTimeFieldTest.getAsText:42
[INFO] 
[ERROR] org.joda.time.chrono.DayOfWeekFromSundayDateTimeFieldTest.getAsTextFieldValue
[ERROR]   Run 1: DayOfWeekFromSundayDateTimeFieldTest.getAsTextFieldValue:56
[ERROR]   Run 2: DayOfWeekFromSundayDateTimeFieldTest.getAsTextFieldValue:56
[ERROR]   Run 3: DayOfWeekFromSundayDateTimeFieldTest.getAsTextFieldValue:56
[ERROR]   Run 4: DayOfWeekFromSundayDateTimeFieldTest.getAsTextFieldValue:56
```

This PR sets the `Locale` to `US`, providing successful test whatever is the user `Locale`.