### PR TITLE
fix: failing to process NAN number number for json format

### DIFF
--- a/services/jobs/src/main/java/com/dremio/service/jobs/QueryProfileParser.java
+++ b/services/jobs/src/main/java/com/dremio/service/jobs/QueryProfileParser.java
@@ -89,6 +89,7 @@ class QueryProfileParser {
   public QueryProfileParser(final JobId jobId, final QueryProfile queryProfile) throws IOException {
     mapper = new ObjectMapper();
     mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+    mapper.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS,true);
     operatorToTable = Maps.newHashMap();
     jobDetails = new JobDetails();
     jobStats = new JobStats();


### PR DESCRIPTION
whent the json file contain `NaN` value, the dremio thrown an error of 
`Exception in thread “main” com.fasterxml.jackson.core.JsonParseException: Non-standard token ‘NaN’: enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow` 
