### PR TITLE
fix: Make FilterSortTransposeRule copy the entire SortRel

### DIFF
--- a/sabot/kernel/src/main/java/com/dremio/exec/planner/transpose/FilterSortTransposeRule.java
+++ b/sabot/kernel/src/main/java/com/dremio/exec/planner/transpose/FilterSortTransposeRule.java
@@ -40,7 +40,7 @@ public final class FilterSortTransposeRule extends RelRule<Config> implements Tr
         relBuilder
             .push(sort.getInput())
             .filter(filter.getCondition())
-            .sort(sort.getSortExps())
+            .sortLimit(sort.collation, sort.offset, sort.fetch)
             .build();
 
     call.transformTo(transposed);


### PR DESCRIPTION
The rule doesn't copy the sort entire collation, but just the fieldIndex. This leads to an always ASC sort even if it was DESC before the transformation.