### PR TITLE
feat: Add ContainerCredentialsProvider for EKS Pod Identity / ECS distributed storage

### DIFF
--- a/plugins/s3/src/main/java/com/dremio/plugins/s3/store/S3StoragePlugin.java
+++ b/plugins/s3/src/main/java/com/dremio/plugins/s3/store/S3StoragePlugin.java
@@ -90,6 +90,8 @@ public class S3StoragePlugin
   public static final String AWS_PROFILE_PROVIDER =
       "com.dremio.plugins.s3.store.AWSProfileCredentialsProviderV1";
   public static final String SESSION_ACCESS_KEY_PROVIDER = TemporaryAWSCredentialsProvider.NAME;
+  public static final String CONTAINER_PROVIDER =
+      "software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider";
 
   private final AWSCredentialsConfigurator awsCredentialsConfigurator;
   private final boolean isAuthTypeNone;

--- a/plugins/s3/src/main/java/com/dremio/plugins/util/AwsCredentialProviderUtils.java
+++ b/plugins/s3/src/main/java/com/dremio/plugins/util/AwsCredentialProviderUtils.java
@@ -18,6 +18,7 @@ package com.dremio.plugins.util;
 import static com.dremio.plugins.s3.store.S3StoragePlugin.ACCESS_KEY_PROVIDER;
 import static com.dremio.plugins.s3.store.S3StoragePlugin.ASSUME_ROLE_PROVIDER;
 import static com.dremio.plugins.s3.store.S3StoragePlugin.AWS_PROFILE_PROVIDER;
+import static com.dremio.plugins.s3.store.S3StoragePlugin.CONTAINER_PROVIDER;
 import static com.dremio.plugins.s3.store.S3StoragePlugin.DREMIO_ASSUME_ROLE_PROVIDER;
 import static com.dremio.plugins.s3.store.S3StoragePlugin.EC2_METADATA_PROVIDER;
 import static com.dremio.plugins.s3.store.S3StoragePlugin.GLUE_ACCESS_KEY_PROVIDER;
@@ -35,6 +36,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.Constants;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider;
 
 /** Utility for creating credential providers based on plugin configuration. */
 public final class AwsCredentialProviderUtils {
@@ -65,6 +67,8 @@ public final class AwsCredentialProviderUtils {
         return new AWSProfileCredentialsProviderV2(config);
       case SESSION_ACCESS_KEY_PROVIDER:
         return new DremioSessionCredentialsProviderV2(config);
+      case CONTAINER_PROVIDER:
+        return ContainerCredentialsProvider.create();
       default:
         throw new IllegalStateException(
             "Invalid AWSCredentialsProvider provided: "

--- a/plugins/s3/src/test/java/com/dremio/plugins/util/AwsCredentialProviderUtilsTest.java
+++ b/plugins/s3/src/test/java/com/dremio/plugins/util/AwsCredentialProviderUtilsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2017-2019 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dremio.plugins.util;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.Constants;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider;
+
+/** Tests for {@link AwsCredentialProviderUtils} */
+public class AwsCredentialProviderUtilsTest {
+
+  @Test
+  public void testContainerCredentialsProvider() {
+    Configuration config = new Configuration();
+    config.set(
+        Constants.AWS_CREDENTIALS_PROVIDER,
+        "software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider");
+
+    AwsCredentialsProvider provider = AwsCredentialProviderUtils.getCredentialsProvider(config);
+    assertTrue(provider instanceof ContainerCredentialsProvider);
+  }
+
+  @Test
+  public void testNoneProvider() {
+    Configuration config = new Configuration();
+    config.set(
+        Constants.AWS_CREDENTIALS_PROVIDER,
+        "org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider");
+
+    AwsCredentialsProvider provider = AwsCredentialProviderUtils.getCredentialsProvider(config);
+    assertTrue(provider instanceof AnonymousCredentialsProvider);
+  }
+
+  @Test
+  public void testInvalidProviderThrowsException() {
+    Configuration config = new Configuration();
+    config.set(Constants.AWS_CREDENTIALS_PROVIDER, "com.invalid.Provider");
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> AwsCredentialProviderUtils.getCredentialsProvider(config));
+  }
+}


### PR DESCRIPTION
## Summary

When Dremio runs as an ECS task or in an EKS pod using IAM Roles for Service Accounts (IRSA) or EKS Pod Identity, the AWS SDK resolves credentials through the container credentials endpoint (`AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` / `AWS_CONTAINER_CREDENTIALS_FULL_URI` environment variables). However, `AwsCredentialProviderUtils.getCredentialsProvider()` has no case for `ContainerCredentialsProvider`, which means there is no way to configure Dremio's S3 plugin to use container-based credential resolution. Users are forced to fall back to EC2 instance metadata (`EC2_METADATA_PROVIDER`), which does not work in containerized environments.

This PR adds:

- A new `CONTAINER_PROVIDER` constant in `S3StoragePlugin` (`"software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider"`)
- A corresponding `case` in the `AwsCredentialProviderUtils` switch statement that returns `ContainerCredentialsProvider.create()`
- Unit tests for the new provider mapping

The change follows the exact same pattern as the existing `EC2_METADATA_PROVIDER` / `NONE_PROVIDER` / etc. cases. No new dependencies are required — `ContainerCredentialsProvider` is part of `software.amazon.awssdk:auth`, which is already a transitive dependency via `software.amazon.awssdk:s3` and `software.amazon.awssdk:sts`.

### Usage

Set `fs.s3a.aws.credentials.provider` to `software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider` in the source's connection properties, or wire it through the auth type configuration.

## Test plan

- [x] Added `AwsCredentialProviderUtilsTest` with tests for the container provider case, anonymous provider case, and invalid provider exception case
- [ ] Verify the change compiles with `mvn compile -pl plugins/s3`
- [ ] Verify tests pass with `mvn test -pl plugins/s3 -Dtest=AwsCredentialProviderUtilsTest`
- [ ] Deploy to an EKS cluster with IRSA/Pod Identity and confirm S3 source connects successfully